### PR TITLE
Stop adding an extra browser history on page navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vivliostyle-js-viewer",
-  "version": "0.2.0",
+  "version": "0.2.1-pre",
   "description": "Paged viewer using Vivliostyle.js as its layout engine",
   "scripts": {
     "setup-local-vivliostyle": "node scripts/setup-local-vivliostyle.js",

--- a/src/js/stores/url-parameters.js
+++ b/src/js/stores/url-parameters.js
@@ -5,6 +5,7 @@ function getRegExpForParameter(name) {
 }
 
 function URLParameterStore() {
+    this.history = window ? window.history : {};
     this.location = window ? window.location : {url: ""};
 }
 
@@ -31,7 +32,11 @@ URLParameterStore.prototype.setParameter = function(name, value) {
     } else {
         updated = url + (url.match(/#/) ? "&" : "#") + name + "=" + value;
     }
-    this.location.href = updated;
+    if (this.history.replaceState) {
+        this.history.replaceState(null, "", updated);
+    } else {
+        this.location.href = updated;
+    }
 };
 
 export default new URLParameterStore();

--- a/test/spec/models/document-options-spec.js
+++ b/test/spec/models/document-options-spec.js
@@ -2,13 +2,16 @@ import DocumentOptions from "../../../src/js/models/document-options";
 import urlParameters from "../../../src/js/stores/url-parameters"
 
 describe("DocumentOptions", function() {
-    var location;
+    var history, location;
 
     beforeEach(function() {
+        history = urlParameters.history;
+        urlParameters.history = {};
         location = urlParameters.location;
     });
 
     afterEach(function() {
+        urlParameters.history = history;
         urlParameters.location = location;
     });
 

--- a/test/spec/stores/url-parameters-spec.js
+++ b/test/spec/stores/url-parameters-spec.js
@@ -2,13 +2,16 @@ import stringUtil from "../../../src/js/utils/string-util";
 import urlParameters from "../../../src/js/stores/url-parameters";
 
 describe("URLParameterStore", function() {
-    var location;
+    var history, location;
 
-    beforeEach(function () {
+    beforeEach(function() {
+        history = urlParameters.history;
+        urlParameters.history = {};
         location = urlParameters.location;
     });
 
     afterEach(function() {
+        urlParameters.history = history;
         urlParameters.location = location;
     });
 
@@ -63,6 +66,17 @@ describe("URLParameterStore", function() {
             urlParameters.setParameter("あいうえお", "さしすせそ");
 
             expect(urlParameters.location.href).toBe("http://example.com#あいうえお=さしすせそ");
+        });
+
+        it("use history.replaceState if available", function() {
+            urlParameters.history.replaceState = function() {};
+            spyOn(urlParameters.history, "replaceState");
+            urlParameters.location = {href: "http://example.com"};
+            urlParameters.setParameter("cc", "dd");
+
+            // dummy location.href does not change
+            expect(urlParameters.location.href).toBe("http://example.com");
+            expect(urlParameters.history.replaceState).toHaveBeenCalledWith(null, "", "http://example.com#cc=dd");
         });
     });
 });


### PR DESCRIPTION
- Issue: #4
- Use `history.replaceState` if available, instead of directly writing `location.href`.