### PR TITLE
Support EPUB loading

### DIFF
--- a/src/js/models/document-options.js
+++ b/src/js/models/document-options.js
@@ -4,6 +4,7 @@ import PageSize from "./page-size";
 
 function getDocumentOptionsFromURL() {
     return {
+        epubUrl: urlParameters.getParameter("b"),
         url: urlParameters.getParameter("x"),
         fragment: urlParameters.getParameter("f")
     };
@@ -11,6 +12,7 @@ function getDocumentOptionsFromURL() {
 
 function DocumentOptions() {
     var urlOptions = getDocumentOptionsFromURL();
+    this.epubUrl = ko.observable(urlOptions.epubUrl || "");
     this.url = ko.observable(urlOptions.url || "");
     this.fragment = ko.observable(urlOptions.fragment || "");
     this.pageSize = new PageSize();

--- a/src/js/viewmodels/viewer.js
+++ b/src/js/viewmodels/viewer.js
@@ -63,7 +63,11 @@ Viewer.prototype.loadDocument = function(documentOptions, viewerOptions) {
         this.viewerOptions_.copyFrom(viewerOptions);
     }
     this.documentOptions_ = documentOptions;
-    this.viewer_.loadDocument(documentOptions.url(), documentOptions.toObject(), this.viewerOptions_.toObject());
+    if (documentOptions.url()) {
+        this.viewer_.loadDocument(documentOptions.url(), documentOptions.toObject(), this.viewerOptions_.toObject());
+    } else if (documentOptions.epubUrl()) {
+        this.viewer_.loadEPUB(documentOptions.epubUrl(), documentOptions.toObject(), this.viewerOptions_.toObject());
+    }
 };
 
 Viewer.prototype.navigateToPrevious = function() {

--- a/test/spec/models/document-options-spec.js
+++ b/test/spec/models/document-options-spec.js
@@ -20,7 +20,15 @@ describe("DocumentOptions", function() {
             urlParameters.location = {href: "http://example.com#x=abc/def.html&f=ghi"};
             var options = new DocumentOptions();
 
+            expect(options.epubUrl()).toBe("");
             expect(options.url()).toBe("abc/def.html");
+            expect(options.fragment()).toBe("ghi");
+
+            urlParameters.location = {href: "http://example.com#b=abc/&f=ghi"};
+            options = new DocumentOptions();
+
+            expect(options.epubUrl()).toBe("abc/");
+            expect(options.url()).toBe("");
             expect(options.fragment()).toBe("ghi");
         });
     });


### PR DESCRIPTION
- An unzipped EPUB directory can be loaded by `#b=[URL of EPUB directory]` parameter